### PR TITLE
React.js: update cheatsheet URL

### DIFF
--- a/30_reactjs/index.html
+++ b/30_reactjs/index.html
@@ -377,7 +377,7 @@ export default Footer;
   - https://www.toptal.com/react/tips-and-practices
   - https://github.com/planningcenter/react-patterns
 - CheatSheets
-  - http://ricostacruz.com/cheatsheets/react.html
+  - https://devhints.io/react
   - http://reactcheatsheet.com/
 
 ---


### PR DESCRIPTION
http://ricostacruz.com/cheatsheets is now https://devhints.io :) (The old URL's are still accessible for now.)

See: https://devhints.io/react